### PR TITLE
使用Pyinstaller打包为单执行文件

### DIFF
--- a/jionlp/__init__.py
+++ b/jionlp/__init__.py
@@ -23,7 +23,8 @@ logging = set_logger(level='INFO', log_dir_name='.jionlp_logs')
 DIR_PATH = os.path.dirname(os.path.abspath(__file__))
 for file_name in UNZIP_FILE_LIST:
     if not os.path.exists(os.path.join(DIR_PATH, 'dictionary', file_name)):
-        unzip_file()
+        zip_file = '.'.join(file_name.split('.')[:-1]) + '.zip'
+        unzip_file(zip_file)
 
 
 history = """

--- a/jionlp/util/zip_file.py
+++ b/jionlp/util/zip_file.py
@@ -8,12 +8,16 @@
 
 
 import os
+import sys
 import shutil
 import zipfile
 
 
 FILE_PATH = os.path.abspath(__file__)
 DIR_PATH = os.path.dirname(os.path.dirname(FILE_PATH))
+
+if hasattr(sys, 'frozen'):
+    DIR_PATH = os.path.dirname(os.path.realpath(sys.executable))
 
 UNZIP_FILE_LIST = [
     'china_location.txt', 'chinese_char_dictionary.txt',


### PR DESCRIPTION
使用Pyinstaller打包为单执行文件后，无法加载词典内容。只能把dictionary文件夹和对应的zip文件拷贝到执行文件同目录下。

- 适配执行文件运行时对词典解压的判断