### PR TITLE
read_file_by_line性能差导致首次加载词典缓慢，优化加载速度

### DIFF
--- a/jionlp/dictionary/dictionary_loader.py
+++ b/jionlp/dictionary/dictionary_loader.py
@@ -101,9 +101,9 @@ def china_location_loader(detail=False):
             若为 False，则返回 省、市、县区 三级信息
 
     """
-    location_jio = read_file_by_line(
-        os.path.join(GRAND_DIR_PATH, 'dictionary/china_location.txt'),
-        strip=False)
+    location_jio = None
+    with open(os.path.join(GRAND_DIR_PATH, 'dictionary/china_location.txt'), 'r', encoding='utf-8') as f:
+        location_jio = f.readlines()
     
     cur_province = None
     cur_city = None


### PR DESCRIPTION
```python
from jionlp import parse_location
import time

start = time.time()
print(parse_location("北京市"))
end = time.time()
print('time',end-start)
```
### 修改后:
['北京市', '北京市', None]
time **0.3006172180175781**
### 修改前:
['北京市', '北京市', None]
time **6.639909267425537**  

另外，可以考虑将下述返回结果存成json提高加载速度，不用每次解析这个大的txt词典，试了一下存成json后加载时间在8ms左右https://github.com/dongrixinyu/JioNLP/blob/4e39494e7b987640830c26afdb8b45b4bf334126/jionlp/dictionary/dictionary_loader.py#L160 