### PR TITLE
关闭按行加载json提高性能

### DIFF
--- a/jionlp/dictionary/dictionary_loader.py
+++ b/jionlp/dictionary/dictionary_loader.py
@@ -80,7 +80,7 @@ def char_distribution_loader():
 
     """
     char_info = read_file_by_line(
-        os.path.join(GRAND_DIR_PATH, 'dictionary', 'char_distribution.json'))
+        os.path.join(GRAND_DIR_PATH, 'dictionary', 'char_distribution.json'),auto_loads_json=True)
 
     char_info_dict = dict()
     total_num = sum([item[1] for item in char_info])
@@ -520,7 +520,7 @@ def word_distribution_loader():
 
     """
     word_info = read_file_by_line(
-        os.path.join(GRAND_DIR_PATH, 'dictionary', 'word_distribution.json'))
+        os.path.join(GRAND_DIR_PATH, 'dictionary', 'word_distribution.json'),auto_loads_json=True)
 
     word_info_dict = dict()
     total_num = sum([item[1] for item in word_info])

--- a/jionlp/util/file_io.py
+++ b/jionlp/util/file_io.py
@@ -94,17 +94,16 @@ def read_file_by_iter(file_path, line_num=None,
 
 def read_file_by_line(file_path, line_num=None, 
                       skip_empty_line=True, strip=True,
-                      auto_loads_json=True):
+                      auto_loads_json=False):
     """ 读取一个文件的前 N 行，按列表返回，
     文件中按行组织，要求 utf-8 格式编码的自然语言文本。
-    若每行元素为 json 格式可自动加载。
 
     Args:
         file_path(str): 文件路径
         line_num(int): 读取文件中的行数，若不指定则全部按行读出
         skip_empty_line(boolean): 是否跳过空行
         strip: 将每一行的内容字符串做 strip() 操作
-        auto_loads_json(bool): 是否自动将每行使用 json 加载，默认是
+        auto_loads_json(bool): 是否自动将每行使用 json 加载，默认为False，提高加载速度
 
     Returns:
         list: line_num 行的内容列表


### PR DESCRIPTION
换个账号，在https://github.com/dongrixinyu/JioNLP/pull/105 基础上又仔细看了一下，性能损失主要是默认按行加载json，看了一下绝大部分词典加载时无需按行加载json，按需开启，提高加载性能