### PR TITLE
fix location parser bug and add unit test

### DIFF
--- a/jionlp/gadget/location_parser.py
+++ b/jionlp/gadget/location_parser.py
@@ -249,6 +249,13 @@ class LocationParser(object):
         candidate_admin_list = [item for item in candidate_admin_list
                                 if item[-2] == max_matched_num]
 
+        # 对于有些新旧地名简称相同，且省市县不按靠前的位置依次排开的，删除旧地名
+        # 这种情况下，candidate_admin_list包含2个行政区划且offset中地址的 “索引”相同
+        if len(candidate_admin_list) == 2:
+            if [i[0] for i in candidate_admin_list[0][-1]] == [i[0] for i in candidate_admin_list[1][-1]]:
+                # 删除旧地名
+                candidate_admin_list = [item for item in candidate_admin_list if item[4] is True]
+
         # 此时，若仅有一个地址被匹配，则应当直接返回正确的结果
         if len(candidate_admin_list) == 1:
             result = self._get_final_res(

--- a/test/test_location_parser.py
+++ b/test/test_location_parser.py
@@ -13,7 +13,8 @@ class TestLocationParser(unittest.TestCase):
 
         location_string_list = [
             ['柳州地区忻城县', False, True,
-             {'province': '广西壮族自治区', 'city': '来宾市', 'county': '忻城县', 'detail': '', 'full_location': '广西壮族自治区来宾市忻城县',
+             {'province': '广西壮族自治区', 'city': '来宾市', 'county': '忻城县', 'detail': '',
+              'full_location': '广西壮族自治区来宾市忻城县',
               'orig_location': '柳州地区忻城县'}
              ],
             ['湖北省襄樊市小水街222号', False, True,
@@ -99,7 +100,8 @@ class TestLocationParser(unittest.TestCase):
              ],
             # 市、县重名,
             ['西安交通大学', True, False,
-             {'province': '陕西省', 'city': '西安市', 'county': None, 'detail': '交通大学', 'full_location': '陕西省西安市交通大学',
+             {'province': '陕西省', 'city': '西安市', 'county': None, 'detail': '交通大学',
+              'full_location': '陕西省西安市交通大学',
               'orig_location': '西安交通大学', 'town': None, 'village': None}
              ],  # 此例会和 “吉林省通辽市西安区” 混淆
             ['河北省秦皇岛市经济技术开发区', True, False,
@@ -133,7 +135,16 @@ class TestLocationParser(unittest.TestCase):
               'detail': '',
               'full_location': '山东省济南市莱芜区',
               'orig_location': '莱芜'}
-            ]
+             ],
+            # 新津区新旧地名简称都是新津
+            ['成都市新津县金华镇清云北路2号（四川新津工业园）', False, False,
+             {'province': '四川省',
+              'city': '成都市',
+              'county': '新津区',
+              'detail': '金华镇清云北路2号（四川新津工业园）',
+              'full_location': '四川省成都市新津区金华镇清云北路2号（四川新津工业园）',
+              'orig_location': '成都市新津县金华镇清云北路2号（四川新津工业园）'}
+             ]
         ]
 
         for item in location_string_list:
@@ -145,11 +156,9 @@ class TestLocationParser(unittest.TestCase):
 
 
 if __name__ == '__main__':
-
     suite = unittest.TestSuite()
     test_location_parser = [TestLocationParser('test_location_parser')]
     suite.addTests(test_location_parser)
 
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)
-


### PR DESCRIPTION
1、修正当新旧地点简称相同，且省市区不按顺序靠前排列时，无法正确返回行政区划代码的错误，例如当地址为“成都市新津县金华镇清云北路2号（四川新津工业园）”时，当前版本返回值为：
`{'province': None, 'city': None, 'county': None, 'detail': '成都市新津县金华镇清云北路2号（四川新津工业园）', 'full_location': '成都市新津县金华镇清云北路2号（四川新津工业园）', 'orig_location': '成都市新津县金华镇清云北路2号（四川新津工业园）'}`
修正后，返回值为：
`{'province': '四川省', 'city': '成都市',  'county': '新津区',  'detail': '金华镇清云北路2号（四川新津工业园）',  'full_location': '四川省成都市新津区金华镇清云北路2号（四川新津工业园）',  'orig_location': '成都市新津县金华镇清云北路2号（四川新津工业园）'}`
2、添加了1条单元测试
`['成都市新津县金华镇清云北路2号（四川新津工业园）', False, False,
             {'province': '四川省',
              'city': '成都市',
              'county': '新津区',
              'detail': '金华镇清云北路2号（四川新津工业园）',
              'full_location': '四川省成都市新津区金华镇清云北路2号（四川新津工业园）',
              'orig_location': '成都市新津县金华镇清云北路2号（四川新津工业园）'}
             ]`