### PR TITLE
fix ner.extract_time support multiple "上" or "下"

### DIFF
--- a/jionlp/rule/rule_pattern.py
+++ b/jionlp/rule/rule_pattern.py
@@ -368,7 +368,7 @@ MONTH_STRING = MONTH_NUM_STRING + r'月(份)?'
 MONTH_NUM_STRING = MONTH_NUM_STRING[:-2] + r'两])'  # 1~12 order month num
 BLUR_MONTH_STRING = r'(初|[一]开年|伊始|末|尾|终|底|[上下]半年|[暑寒][假期]|[前中后]期)'
 LUNAR_MONTH_STRING = r'(闰)?([正一二三四五六七八九十冬腊]|十[一二]|[1-9]|1[012])月'
-LIMIT_MONTH_STRING = r'([下上]((一)?个)?|同|本|当|次|这)月'
+LIMIT_MONTH_STRING = r'([下上]+((一)?个)?|同|本|当|次|这)月'
 SELF_EVI_LUNAR_MONTH_STRING = r'((闰)?[正冬腊]|闰([一二三四五六七八九十]|十[一二]|[1-9]|1[012]))月'
 
 # 周

--- a/test/test_time_extractor.py
+++ b/test/test_time_extractor.py
@@ -37,7 +37,10 @@ class TestTimeExtractor(unittest.TestCase):
             ['调高二十四点五度', []],
             ['调高24点5度', []],
             ['升高10点五度', []],
-            ['是一个十一点的事', [{'text': '十一点', 'offset': [3, 6], 'type': 'time_point'}]]
+            ['是一个十一点的事', [{'text': '十一点', 'offset': [3, 6], 'type': 'time_point'}]],
+            ['下下下周一', [{'text': '下下下周一', 'offset': [0, 5], 'type': 'time_point'}]],
+            ['上上个月五号', [{'text': '上上个月五号', 'offset': [0, 6], 'type': 'time_point'}]],
+            ['下下个季度', [{'text': '下下个季度', 'offset': [0, 5], 'type': 'time_span'}]],
         ]
 
         for item in text_string_list:


### PR DESCRIPTION
solve [#203 ](https://github.com/dongrixinyu/JioNLP/issues/203)
ner.extract_time支持正确解析包括多个上或下的时间字符串，如“上上上周二”、“上上个月五号”、“上上个季度”等